### PR TITLE
Move export file configuration to DI

### DIFF
--- a/Components/Output/Csv.php
+++ b/Components/Output/Csv.php
@@ -11,18 +11,14 @@ class Csv implements StreamInterface
     /** @var File */
     private $handle;
 
-    /** @var string */
-    private $delimiter;
-
-    public function __construct(string $fileName, string $delimiter)
+    public function __construct(File $handle)
     {
-        $this->handle    = new File($fileName . '.csv', 'wr+');
-        $this->delimiter = $delimiter;
+        $this->handle = $handle;
     }
 
     public function addEntity(array $entity): void
     {
-        $this->handle->fputcsv($entity, $this->delimiter);
+        $this->handle->fputcsv($entity);
     }
 
     public function getContent(): string

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -26,8 +26,15 @@
         </service>
 
         <service id="OmikronFactfinder\Components\Output\Csv">
-            <argument type="expression">service('OmikronFactfinder\\Components\\Configuration').getChannel()</argument>
-            <argument>%omikron_factfinder.export.delimiter%</argument>
+            <argument type="service">
+                <service class="SplFileObject">
+                    <argument type="expression">"export." ~ service('OmikronFactfinder\\Components\\Configuration').getChannel() ~ ".csv"</argument>
+                    <argument type="string">w+</argument>
+                    <call method="setCsvControl">
+                        <argument>%omikron_factfinder.export.delimiter%</argument>
+                    </call>
+                </service>
+            </argument>
         </service>
 
         <service id="OmikronFactfinder\Components\Data\Article\Type\BaseArticle" abstract="true">


### PR DESCRIPTION
The file is passed already configured now and ready to be written. Also, the file name had to be corrected according to the standard import handler. Tested with Shopware 5.6.7 and PHP 7.2