### PR TITLE
Add custom fields to export feed automatically

### DIFF
--- a/Components/Data/Article/FieldProvider.php
+++ b/Components/Data/Article/FieldProvider.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OmikronFactfinder\Components\Data\Article;
+
+use OmikronFactfinder\Components\Data\Article\Fields\ArticleFieldInterface;
+
+class FieldProvider
+{
+    /** @var ArticleFieldInterface[] */
+    private $fields;
+
+    /** @var string[] */
+    private $columns;
+
+    public function __construct(\Traversable $fields, array $columns)
+    {
+        $this->fields  = iterator_to_array($fields);
+        $this->columns = $columns;
+    }
+
+    public function getColumns(): array
+    {
+        return array_unique(array_merge($this->columns, array_map([$this, 'getFieldName'], $this->fields)));
+    }
+
+    public function getFields(): array
+    {
+        return $this->fields;
+    }
+
+    private function getFieldName(ArticleFieldInterface $field): string
+    {
+        return $field->getName();
+    }
+}

--- a/Components/Data/Article/Type/MainArticleProvider.php
+++ b/Components/Data/Article/Type/MainArticleProvider.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OmikronFactfinder\Components\Data\Article\Type;
 
+use OmikronFactfinder\Components\Data\Article\FieldProvider;
 use OmikronFactfinder\Components\Data\Article\Fields\ArticleFieldInterface;
 use OmikronFactfinder\Components\Data\DataProviderInterface;
 use OmikronFactfinder\Components\Data\ExportEntityInterface;
@@ -14,13 +15,13 @@ class MainArticleProvider extends BaseArticle implements DataProviderInterface
     /** @var ArticleProviderFactory */
     private $providerFactory;
 
-    /** @var ArticleFieldInterface[] */
-    private $articleFields;
+    /** @var FieldProvider */
+    private $fieldProvider;
 
-    public function __construct(ArticleProviderFactory $articleProviderFactory, \Traversable $articleFields)
+    public function __construct(ArticleProviderFactory $articleProviderFactory, FieldProvider $fieldProvider)
     {
         $this->providerFactory = $articleProviderFactory;
-        $this->articleFields   = iterator_to_array($articleFields);
+        $this->fieldProvider   = $fieldProvider;
     }
 
     public function getId(): int
@@ -30,7 +31,7 @@ class MainArticleProvider extends BaseArticle implements DataProviderInterface
 
     public function toArray(): array
     {
-        $data = array_reduce($this->articleFields, function (array $fields, ArticleFieldInterface $field) {
+        $data = array_reduce($this->fieldProvider->getFields(), function (array $fields, ArticleFieldInterface $field) {
             return $fields + [$field->getName() => $field->getValue($this->article)];
         }, parent::toArray());
 

--- a/Components/Service/ExportService.php
+++ b/Components/Service/ExportService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace OmikronFactfinder\Components\Service;
 
+use OmikronFactfinder\Components\Data\Article\FieldProvider;
 use OmikronFactfinder\Components\Data\DataProviderInterface;
 use OmikronFactfinder\Components\Filter\FilterInterface;
 use OmikronFactfinder\Components\Output\StreamInterface;
@@ -16,20 +17,24 @@ class ExportService implements ExportServiceInterface
     /** @var FilterInterface */
     private $filter;
 
-    /** @var array */
-    private $columns;
+    /** @var FieldProvider */
+    private $fieldProvider;
 
-    public function __construct(DataProviderInterface $dataProvider, FilterInterface $filter, array $columns)
-    {
-        $this->dataProvider = $dataProvider;
-        $this->filter       = $filter;
-        $this->columns      = $columns;
+    public function __construct(
+        DataProviderInterface $dataProvider,
+        FilterInterface $filter,
+        FieldProvider $fieldProvider
+    ) {
+        $this->dataProvider  = $dataProvider;
+        $this->filter        = $filter;
+        $this->fieldProvider = $fieldProvider;
     }
 
     public function generate(StreamInterface $stream): void
     {
-        $emptyRecord = array_combine($this->columns, array_fill(0, count($this->columns), ''));
-        $stream->addEntity($this->columns);
+        $columns     = $this->fieldProvider->getColumns();
+        $emptyRecord = array_combine($columns, array_fill(0, count($columns), ''));
+        $stream->addEntity($columns);
         foreach ($this->dataProvider->getEntities() as $entity) {
             $entityData = array_merge($emptyRecord, array_intersect_key($entity->toArray(), $emptyRecord));
             $stream->addEntity($this->prepare($entityData));

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -45,9 +45,9 @@
 
         <service id="OmikronFactfinder\Components\Data\Article\Type\MainArticleProvider"
                  parent="OmikronFactfinder\Components\Data\Article\Type\BaseArticle"
+                 autowire="true"
                  shared="false">
             <argument type="service" id="OmikronFactfinder\Components\Data\Article\Type\ArticleProviderFactory" />
-            <argument type="tagged" tag="factfinder.export.field" />
         </service>
 
         <service id="OmikronFactfinder\Components\Data\Article\Type\VariantProvider"
@@ -67,10 +67,9 @@
             <argument type="service" id="config" />
         </service>
 
-        <service id="OmikronFactfinder\Components\Service\ExportService">
+        <service id="OmikronFactfinder\Components\Service\ExportService" autowire="true">
             <argument type="service" id="OmikronFactfinder\Components\Data\Article\ArticleDataProvider" />
             <argument type="service" id="OmikronFactfinder\Components\Filter\TextFilter" />
-            <argument>%omikron_factfinder.export.articles.columns%</argument>
         </service>
 
         <service id="OmikronFactfinder\Components\Service\UploadService">

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -46,9 +46,7 @@
         <service id="OmikronFactfinder\Components\Data\Article\Type\MainArticleProvider"
                  parent="OmikronFactfinder\Components\Data\Article\Type\BaseArticle"
                  autowire="true"
-                 shared="false">
-            <argument type="service" id="OmikronFactfinder\Components\Data\Article\Type\ArticleProviderFactory" />
-        </service>
+                 shared="false" />
 
         <service id="OmikronFactfinder\Components\Data\Article\Type\VariantProvider"
                  parent="OmikronFactfinder\Components\Data\Article\Type\BaseArticle"

--- a/Resources/services.xml
+++ b/Resources/services.xml
@@ -31,7 +31,7 @@
                     <argument type="expression">"export." ~ service('OmikronFactfinder\\Components\\Configuration').getChannel() ~ ".csv"</argument>
                     <argument type="string">w+</argument>
                     <call method="setCsvControl">
-                        <argument>%omikron_factfinder.export.delimiter%</argument>
+                        <argument>%factfinder.export.delimiter%</argument>
                     </call>
                 </service>
             </argument>

--- a/Resources/services/export_fields.xml
+++ b/Resources/services/export_fields.xml
@@ -9,6 +9,11 @@
             <bind key="$router" id="router" type="service" />
         </defaults>
 
+        <service id="OmikronFactfinder\Components\Data\Article\FieldProvider">
+            <argument type="tagged" tag="factfinder.export.field" />
+            <argument>%omikron_factfinder.export.articles.columns%</argument>
+        </service>
+
         <prototype namespace="OmikronFactfinder\Components\Data\Article\Fields\"
                    resource="../../Components/Data/Article/Fields" />
     </services>

--- a/Resources/services/export_fields.xml
+++ b/Resources/services/export_fields.xml
@@ -5,13 +5,13 @@
 
     <services>
         <defaults public="false" autoconfigure="true" autowire="true">
-            <bind key="$imageSize">%omikron_factfinder.export.thumbnail_size%</bind>
+            <bind key="$imageSize">%factfinder.export.thumbnail_size%</bind>
             <bind key="$router" id="router" type="service" />
         </defaults>
 
         <service id="OmikronFactfinder\Components\Data\Article\FieldProvider">
             <argument type="tagged" tag="factfinder.export.field" />
-            <argument>%omikron_factfinder.export.articles.columns_base%</argument>
+            <argument>%factfinder.export.columns.base%</argument>
         </service>
 
         <prototype namespace="OmikronFactfinder\Components\Data\Article\Fields\"

--- a/Resources/services/export_fields.xml
+++ b/Resources/services/export_fields.xml
@@ -11,7 +11,7 @@
 
         <service id="OmikronFactfinder\Components\Data\Article\FieldProvider">
             <argument type="tagged" tag="factfinder.export.field" />
-            <argument>%omikron_factfinder.export.articles.columns%</argument>
+            <argument>%omikron_factfinder.export.articles.columns_base%</argument>
         </service>
 
         <prototype namespace="OmikronFactfinder\Components\Data\Article\Fields\"

--- a/Resources/services/parameters.xml
+++ b/Resources/services/parameters.xml
@@ -4,7 +4,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="omikron_factfinder.export.articles.columns" type="collection">
+        <parameter key="omikron_factfinder.export.articles.columns_base" type="collection">
             <parameter key="ProductNumber">ProductNumber</parameter>
             <parameter key="Master">Master</parameter>
             <parameter key="Name">Name</parameter>

--- a/Resources/services/parameters.xml
+++ b/Resources/services/parameters.xml
@@ -4,7 +4,7 @@
            xsi:schemaLocation="http://symfony.com/schema/dic/services http://symfony.com/schema/dic/services/services-1.0.xsd">
 
     <parameters>
-        <parameter key="omikron_factfinder.export.articles.columns_base" type="collection">
+        <parameter key="factfinder.export.columns.base" type="collection">
             <parameter key="ProductNumber">ProductNumber</parameter>
             <parameter key="Master">Master</parameter>
             <parameter key="Name">Name</parameter>
@@ -17,8 +17,8 @@
             <parameter key="HasVariants">HasVariants</parameter>
         </parameter>
 
-        <parameter key="omikron_factfinder.export.delimiter" type="string">;</parameter>
+        <parameter key="factfinder.export.delimiter" type="string">;</parameter>
 
-        <parameter key="omikron_factfinder.export.thumbnail_size" type="string">600x600</parameter>
+        <parameter key="factfinder.export.thumbnail_size" type="string">600x600</parameter>
     </parameters>
 </container>

--- a/Resources/services/parameters.xml
+++ b/Resources/services/parameters.xml
@@ -12,14 +12,9 @@
             <parameter key="Weight">Weight</parameter>
             <parameter key="Short">Short</parameter>
             <parameter key="Description">Description</parameter>
-            <parameter key="ImageUrl">ImageUrl</parameter>
-            <parameter key="Price">Price</parameter>
             <parameter key="Brand">Brand</parameter>
             <parameter key="Availability">Availability</parameter>
             <parameter key="HasVariants">HasVariants</parameter>
-            <parameter key="CategoryPath">CategoryPath</parameter>
-            <parameter key="Deeplink">Deeplink</parameter>
-            <parameter key="Attributes">Attributes</parameter>
         </parameter>
 
         <parameter key="omikron_factfinder.export.delimiter" type="string">;</parameter>


### PR DESCRIPTION
- Solves issue: #1 
- Description: Custom product fields (tagged with factfinder.export.field) should be automatically added to the feed
- Tested with Shopware version(s): 5.6.8
- Tested with PHP version(s): 7.2.25
