### PR TITLE
Don't add 'Content-Type' header on NG POST requests with empty body

### DIFF
--- a/Components/Service/PushImportService.php
+++ b/Components/Service/PushImportService.php
@@ -53,7 +53,6 @@ class PushImportService
         foreach ($this->pushImportConfiguration->getImportTypes() as $type) {
             $this->client->post($this->getBaseEndpoint() . $type . '?' . http_build_query($params), [
                 'Accept'        => 'application/json',
-                'Content-Type'  => 'application/json',
                 'Authorization' => $this->configuration->getCredentials(),
             ]);
         }

--- a/Subscriber/Tracking.php
+++ b/Subscriber/Tracking.php
@@ -73,7 +73,7 @@ class Tracking implements SubscriberInterface
                 'masterId' => $this->getMasterProductNumber($product),
                 'count'    => $orderItem['quantity'],
                 'price'    => $this->numberFormatter->format((float) $orderItem['price']),
-                'sid'      => substr($orderItem['sessionID'], 0, 30),
+                'sid'      => substr(md5($orderItem['sessionID']), 0, 30),
                 'userId'   => $orderItem['userID'],
             ]);
         }, $arg['details']));
@@ -89,7 +89,7 @@ class Tracking implements SubscriberInterface
             'masterId' => $this->getMasterProductNumber($product),
             'count'    => $cartItem->getQuantity(),
             'price'    => $this->numberFormatter->format($price * (1 + $tax / 100)),
-            'sid'      => substr($this->session->get('sessionId'), 0, 30),
+            'sid'      => substr(md5($this->session->get('sessionId')), 0, 30),
             'userId'   => (int) $this->session->get('sUserId', 0),
         ]);
     }


### PR DESCRIPTION
- Description: Compare https://github.com/FACT-Finder-Web-Components/oxid-eshop-module/pull/58
- Tested with Shopware version(s): v5.6.9
- Tested with PHP version(s): 7.2
