### PR TITLE
Define sort option to prevent duplicate records during export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,22 +6,32 @@ on: [push]
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php: ['7.2']
+        deps: ['lowest', 'stable']
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v2
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
 
       - name: Get Composer cache directory
         id: composer-cache
         run: echo "::set-output name=dir::$(composer config cache-files-dir)"
 
       - name: Load Composer cache
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
-          key: ${{ runner.os }}-composer
+          key: ${{ runner.os }}-${{ matrix.php }}-${{ matrix.deps }}-composer
 
       - name: Install dependencies
-        run: composer install --no-ansi --no-interaction
+        run: composer update --no-ansi --no-interaction --prefer-${{ matrix.deps }}
 
       - name: Run tests
         run: |

--- a/Components/Data/Article/ArticleDetails.php
+++ b/Components/Data/Article/ArticleDetails.php
@@ -38,7 +38,8 @@ class ArticleDetails implements \IteratorAggregate
 
     private function getArticles(int $page, int $pageSize): iterable
     {
+        $sortBy = [['property' => 'article.id']];
         $this->articleResource->setResultMode(Resource::HYDRATE_OBJECT);
-        return $this->articleResource->getList($page * $pageSize, $pageSize, ['active' => true])['data'];
+        return $this->articleResource->getList($page * $pageSize, $pageSize, ['active' => true], $sortBy)['data'];
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     "composer/installers": "^1.8"
   },
   "require-dev": {
-    "friendsofphp/php-cs-fixer": "^2.16",
+    "friendsofphp/php-cs-fixer": "^2.18",
     "phpunit/phpunit": "^7.5"
   },
   "autoload-dev": {


### PR DESCRIPTION
- Description: without defining an unambiguous sort option, there is a chance of duplicate records being exported.
- Tested with Shopware version(s): CE 5.6.9
- Tested with PHP version(s): 7.2.25
