### PR TITLE
Hide recommendation caption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Changelog
+## Unreleased
+
+### Fixed
+ - hide Recommendation header when no records are returned
+ - fix hardcoded record-id in ff-recommendation element
+
 ## [v1.0.1] - 2021.04.21
 
 ### Added

--- a/Resources/views/frontend/factfinder/content/recommendation.tpl
+++ b/Resources/views/frontend/factfinder/content/recommendation.tpl
@@ -1,8 +1,8 @@
 <div class="recommendation">
-  <div class="recommendation--title">{s name='Recommendation' namespace='frontend/omikron/factfinder'}Recommendation{/s}</div>
   <div class="product-slider recommendation--slider" data-product-slider="true" data-infiniteSlide="false">
     <div class="recommendation--container">
       <ff-recommendation max-results="5" record-id="{$sArticle.mainVariantNumber}" class="product-slider--container is--horizontal">
+        <div class="recommendation--title">{s name='Recommendation' namespace='frontend/omikron/factfinder'}Recommendation{/s}</div>
         {include file='frontend/factfinder/content/record_list_slider.tpl'}
       </ff-recommendation>
     </div>

--- a/Resources/views/frontend/factfinder/content/recommendation.tpl
+++ b/Resources/views/frontend/factfinder/content/recommendation.tpl
@@ -2,7 +2,7 @@
   <div class="recommendation--title">{s name='Recommendation' namespace='frontend/omikron/factfinder'}Recommendation{/s}</div>
   <div class="product-slider recommendation--slider" data-product-slider="true" data-infiniteSlide="false">
     <div class="recommendation--container">
-      <ff-recommendation max-results="5" record-id="510-1983-0211" class="product-slider--container is--horizontal">
+      <ff-recommendation max-results="5" record-id="{$sArticle.mainVariantNumber}" class="product-slider--container is--horizontal">
         {include file='frontend/factfinder/content/record_list_slider.tpl'}
       </ff-recommendation>
     </div>


### PR DESCRIPTION
- Description: 
Hides `Recommendation` header when no records are returned from FACT-Finder
- Tested with Shopware version(s): 
5.6.3
- Tested with PHP version(s):
7.2

