### PR TITLE
FFWEB-2036: Fix hiding Similar Articles tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+## Unreleased
+### Fixed
+ - Fix hiding similar-products tab causes an error if there is are no native similar article fetched from the Shopware backend for a given article 
+
 ## [v1.0.2] - 2021.05.18
 
 ### Added

--- a/Resources/views/frontend/detail/content/tab_navigation.tpl
+++ b/Resources/views/frontend/detail/content/tab_navigation.tpl
@@ -1,0 +1,5 @@
+{extends file='parent:frontend/detail/content/tab_navigation.tpl'}
+{block name="frontend_detail_index_tabs_navigation"}
+  {$sArticle.sSimilarArticles = [1]}
+  {$smarty.block.parent}
+{/block}

--- a/Resources/views/frontend/index/header.tpl
+++ b/Resources/views/frontend/index/header.tpl
@@ -31,7 +31,10 @@
 
       e.factfinder.communication.ResultDispatcher.addCallback('similarProducts', function (similarData) {
         if (similarData.records && !similarData.records.length) {
-          document.querySelector('a[href="#content--similar-products"]').classList.add('ffw-hidden');
+          const similarProductsTab = document.querySelector('a[href="#content--similar-products"]');
+            if (similarProductsTab) {
+                similarProductsTab.classList.add('ffw-hidden');
+            }
         }
       });
     });


### PR DESCRIPTION
- Description: 
Similar articles tab is created only if there are native similar articles fetched from the Shopware backend for a given article. If there are not, the tab is not even rendered which causes an js error during rendering the tab
- Tested with Shopware version(s): 
5.6.5
- Tested with PHP version(s): 
7.2
