### PR TITLE
Add `is-navigation` attribute on category and manufacturer pages to record list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,11 @@
 # Changelog
+## [v1.0.5] - 2021.07.07
+### Added
+ - Added `is-navigation` attribute to main `ff-record-list` (one with subscribe=true) on category and manufacturer pages. This might help detecting whether Web Components should send navigation requests instead of search. 
+
+### Fixed
+- Event data coming from searchbox element is not URLencoded before redirecting to search result page
+
 ## [v1.0.4] - 2021.06.15
 ### Changed
  - Removed Theme_Compiler_Collect_Plugin_Javascript event listener. Now js files are placed in `Resources/frontend/js` and should be loaded automatically.

--- a/Resources/views/frontend/factfinder/category.tpl
+++ b/Resources/views/frontend/factfinder/category.tpl
@@ -30,5 +30,5 @@
 {/block}
 
 {block name='frontend_listing_index_listing'}
-  {include file='frontend/factfinder/listing.tpl'}
+  {include file='frontend/factfinder/listing.tpl' isNavigationPage=true}
 {/block}

--- a/Resources/views/frontend/factfinder/content/record_list.tpl
+++ b/Resources/views/frontend/factfinder/content/record_list.tpl
@@ -1,5 +1,5 @@
 {block name="frontend_factfinder_record_list"}
-  <ff-record-list class="container" subscribe="{($subscribe) ? 'true' : 'false'}" unresolved>
+  <ff-record-list class="container" subscribe="{($subscribe) ? 'true' : 'false'}" unresolved {($isNavigationPage) ? 'is-navigation' : ''}>
     {block name="frontend_factfinder_record"}
       <ff-record class="product--box box--basic">
         <div class="box--content is--rounded">

--- a/Resources/views/frontend/factfinder/listing.tpl
+++ b/Resources/views/frontend/factfinder/listing.tpl
@@ -6,7 +6,7 @@
 {/block}
 
 {block name='frontend_listing_list_inline'}
-  {include file='frontend/factfinder/content/record_list.tpl' subscribe=true}
+  {include file='frontend/factfinder/content/record_list.tpl' subscribe=true isNavigationPage=$isNavigationPage}
 {/block}
 
 {block name='frontend_listing_bottom_paging'}

--- a/Resources/views/frontend/index/header.tpl
+++ b/Resources/views/frontend/index/header.tpl
@@ -12,7 +12,7 @@
       document.addEventListener('before-search', function (event) {
         if (['productDetail', 'getRecords'].lastIndexOf(event.detail.type) === -1) {
           event.preventDefault();
-          window.location = '{url controller='factfinder' action='result'}' + factfinder.common.dictToParameterString(event.detail);
+          window.location = '{url controller='factfinder' action='result'}' + factfinder.common.dictToParameterString(factfinder.common.encodeDict(event.detail));
         }
       });
     </script>


### PR DESCRIPTION
- Description: 
Main ff-record-list element (one with subscribe=true) has additional attribute added `is-navigation` which is added on category and manufacturer pages. This may helps detecting whether Web Components should act as if they were in navigation mode 
- Tested with Shopware version(s): 
5.6.9
- Tested with PHP version(s): 
7.2
