### PR TITLE
FFWEB-2469 Fix searchbox does not appear in mobile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,15 @@
 # Changelog
+## [Unreleased]
+### Fix
+ - Searchbox
+  - searchbox does not appear after clicking on magnifier icon
+  
+### Change
+ - `jquery.search.js` plugin
+  - override `onKeyUp` to prevent sending redundant native suggest calls using `ajax_search` controller
+ -`Resources/views/frontend/index/index.tpl`
+  - restore adding `data-search` in `frontend_index_shop_navigation` block. Lack of this directive disabled the searchbox show/hide functionality in mobile
+
 ## [v3.0.1] - 13.03.2022
 ### Fix
  - fix `sid` attribute is defined in `ff-communication template` causing it to be generated always with same value

--- a/Resources/frontend/js/jquery.search-factfinder-search.js
+++ b/Resources/frontend/js/jquery.search-factfinder-search.js
@@ -1,0 +1,6 @@
+$.overridePlugin('swSearch', {
+    //silence the default suggestions
+    onKeyUp: function(response) {
+        return true;
+    }
+});

--- a/Resources/views/frontend/index/index.tpl
+++ b/Resources/views/frontend/index/index.tpl
@@ -1,11 +1,5 @@
 {extends file='parent:frontend/index/index.tpl'}
 
-{* Prevent Shopware AJAX search *}
-{block name='frontend_index_shop_navigation'}
-  {capture assign='shopNavigation'}{$smarty.block.parent}{/capture}
-  {$shopNavigation|replace:' data-search="true"':''}
-{/block}
-
 {block name='frontend_index_after_body'}
   {$smarty.block.parent}
 


### PR DESCRIPTION
- Description: 
To prevent sending native ajax suggestion calls, the `data-search` directive, which initializes the `swSearch` plugin has been removed. This plugin is unfortunately also responsible for many other interactions. One of these is show/hide searchbox after clicking on magnifier icon while being in mobile mode. This PR restores the `data-search` and define custom plugin that overrides the `swSearch` `onKeyUp` method. This should silence the native suggestion mechanism but persist rest of the functionality, that plugin offers.

- Tested with Shopware version(s): 
5.7
- Tested with PHP version(s): 
7.4
