### PR TITLE
FFWEB-2124: Hide category filter on category page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@
   - override `onKeyUp` to prevent sending redundant native suggest calls using `ajax_search` controller
  -`Resources/views/frontend/index/index.tpl`
   - restore adding `data-search` in `frontend_index_shop_navigation` block. Lack of this directive disabled the searchbox show/hide functionality in mobile
-
+ - Category Page
+  - hide ff-asn-group for Category Path. User should use main navigation instead to correctly update the web components navigation mode state  
+  
 ## [v3.0.1] - 13.03.2022
 ### Fix
  - fix `sid` attribute is defined in `ff-communication template` causing it to be generated always with same value

--- a/Resources/frontend/less/asn.less
+++ b/Resources/frontend/less/asn.less
@@ -67,6 +67,9 @@ ff-asn-group {
   .clusterLevel3 {
     .unitize(margin-left, 62);
   }
+  &.hidden-group {
+    display: none !important;
+  }
 }
 
 ff-slider {

--- a/Resources/views/frontend/factfinder/category.tpl
+++ b/Resources/views/frontend/factfinder/category.tpl
@@ -25,7 +25,7 @@
 
 {block name='frontend_listing_actions_filter_form'}
   <div data-filter-form="true">
-    {include file='frontend/factfinder/content/asn.tpl'}
+    {include file='frontend/factfinder/content/asn.tpl' isNavigationPage=true categoryPathFieldName=$ffCategoryPathFieldName}
     {include file='frontend/factfinder/content/filter_cloud.tpl'}
   </div>
 {/block}

--- a/Resources/views/frontend/factfinder/content/asn.tpl
+++ b/Resources/views/frontend/factfinder/content/asn.tpl
@@ -3,6 +3,10 @@
 {block name='frontend_factfinder_asn'}
   <ff-asn class="filter--facet-container" unresolved>
     {block name='frontend_factfinder_asn_group'}
+      {if $isNavigationPage}
+          <ff-asn-group for-group="{$categoryPathFieldName}ROOT" style="display:none" class="hidden-group" disable-auto-expand>
+          </ff-asn-group>
+      {/if}
       <ff-asn-group class="filter-panel filter--multi-selection" disable-auto-expand>
         <div slot="groupCaption" class="filter-panel--title">
           {'{{group.name}}'}

--- a/Subscriber/CategoryView.php
+++ b/Subscriber/CategoryView.php
@@ -39,7 +39,11 @@ class CategoryView implements SubscriberInterface
 
             if ($id) {
                 $view->extendsTemplate('frontend/factfinder/category.tpl');
-                $view->assign('ffCategoryPath', $this->categoryPath->getValue($id));
+                $categoryPath = $this->categoryPath->getValue($id);
+                $view->assign('ffCategoryPath', $categoryPath);
+                preg_replace_callback('/[^filter=]\w+(?=%3A)/', function (array $match) use ($view) {
+                    $view->assign('ffCategoryPathFieldName', $match[0]);
+                }, $categoryPath);
                 return;
             }
         }


### PR DESCRIPTION
- Description: 
 Hide category filter on category page. usage of the asn will not upate the `category-page` attribute with current value of the category path. Because of that the navigation mode will be in wrong state causing any click tracking events to track wrong category
- Tested with Shopware version(s): 
5.7
- Tested with PHP version(s): 
7.4
